### PR TITLE
Reactivate testing @ github actions

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -36,6 +36,6 @@ jobs:
         run: pip install numpy==1.13
       - name: test install
         run: |
-          pip install wheel
+          pip install wheel tox
           pip install .
-          python setup.py test
+          tox

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -36,6 +36,6 @@ jobs:
         run: pip install numpy==1.13
       - name: test install
         run: |
-          pip install wheel pytest
+          pip install wheel
           pip install .
-          pytest
+          python setup.py test

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -36,6 +36,6 @@ jobs:
         run: pip install numpy==1.13
       - name: test install
         run: |
-          pip install wheel
+          pip install wheel pytest
           pip install .
           pytest

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -36,6 +36,7 @@ jobs:
         run: pip install numpy==1.13
       - name: test install
         run: |
-          pip install wheel tox
+          pip install wheel
           pip install .
-          tox
+          python tests/core_nest_tests.py
+          python tests/example_tests.py

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -38,3 +38,4 @@ jobs:
         run: |
           pip install wheel
           pip install .
+          pytest

--- a/tests/core_nest_tests.py
+++ b/tests/core_nest_tests.py
@@ -222,6 +222,7 @@ class LArNESTTest(unittest.TestCase):
     
     def test_larnest_get_yields(self):
         self.larnest.get_yields(self.it, 100., 500., 1.393)
+        assert False
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core_nest_tests.py
+++ b/tests/core_nest_tests.py
@@ -222,7 +222,6 @@ class LArNESTTest(unittest.TestCase):
     
     def test_larnest_get_yields(self):
         self.larnest.get_yields(self.it, 100., 500., 1.393)
-        assert False
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Seems like testing was disabled in https://github.com/NESTCollaboration/nestpy/pull/93

Looking at some of the changes made there it looks like a different route was chosen than the testing suite provided by the `setup.py`, fine by me - probably would be good to disable that route altogether to avoid confusion.

Just to test that the desired behavior is re-established, I committed [7961b7e](https://github.com/JoranAngevaare/nestpy/pull/8/commits/7961b7eb32d7254d4fdc4ed2b88d477fac6c8de7).